### PR TITLE
Use PHP 8.2 and MySQL 8.2, fix different line endings

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,23 +9,9 @@ services:
     expose:
       - "3306"
 
-## Link an RStudio container to the ergastdb database server 
-#f1dj_rstudio:
-#  image: rocker/tidyverse 
-#  ports:
-#    - "8787:8787"
-#  links:
-#    - ergastdb:ergastdb
-#  volumes:
-#    - ./rstudio:/home/rstudio
-## Test the connection using:
-##library(RMySQL)
-##con=dbConnect(MySQL(),user='root',password='f1',host='ergastdb',port=3306,dbname='ergastdb')
-## dbListTables(con)  
-
   web:
-    build: ./lamp
-    #image: nimmis/apache-php5
+    container_name: ergastapi
+    build: lamp/
     ports:
       - '8000:80'
     volumes:
@@ -35,7 +21,6 @@ services:
     links:
       - ergastdb:ergastdb
 
-#docker-compose up --build -d
-#docker-compose build --force-rm
-#docker-compose up -d
-
+# docker compose up --build -d
+# docker compose build --force-rm
+# docker compose up -d

--- a/ergastdb/Dockerfile
+++ b/ergastdb/Dockerfile
@@ -1,10 +1,17 @@
-FROM mysql:5.7-debian
+FROM mysql:8.2
 
-RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address=0.0.0.0/" /etc/mysql/my.cnf
-
-RUN apt-get update && apt-get install -y wget && apt-get clean
+RUN sed -i -e"s/^bind-address\s*=\s*127.0.0.1/bind-address=0.0.0.0/" /etc/my.cnf
 
 #ADD data/f1db.sql.gz /docker-entrypoint-initdb.d/f1db.sql.gz
 
-RUN wget http://ergast.com/downloads/f1db.sql.gz -P /docker-entrypoint-initdb.d
+RUN curl -s -o /docker-entrypoint-initdb.d/f1db.sql.gz http://ergast.com/downloads/f1db.sql.gz
 RUN gunzip /docker-entrypoint-initdb.d/f1db.sql.gz
+
+RUN echo -e "[client]\n"\
+            "default-character-set = utf8\n\n"\
+            "[mysql]\n"\
+            "default-character-set = utf8\n\n"\
+            "[mysqld]\n"\
+            "collation-server = utf8_unicode_ci\n"\
+            "character-set-server = utf8\n"\
+            "default_authentication_plugin = mysql_native_password\n" >> /etc/my.cnf

--- a/lamp/Dockerfile
+++ b/lamp/Dockerfile
@@ -1,7 +1,5 @@
-FROM nimmis/apache-php5
+FROM php:8.2-apache
 
+RUN docker-php-ext-install mysqli
 RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
-
-
-
 RUN a2enmod rewrite

--- a/webroot/php/api/CircuitTable.inc
+++ b/webroot/php/api/CircuitTable.inc
@@ -21,11 +21,11 @@ if($round) $query .= " AND ra.round='$round'";
 $query .= " ORDER BY ci.circuitRef LIMIT $offset, $limit";
 //echo "$query<br>\n<br>\n";
 
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   if(strcmp($format, "xml") == 0) {
     doXMLHeader($url, $series, $limit, $offset, $total);
@@ -40,7 +40,7 @@ if($result) {
     if(isset($results)) echo " position=\"$results\"";
     if(isset($status)) echo " statusId=\"$status\"";
     echo ">\n";
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $circuitId = $row[0];
       $circuitName = $row[1];
       $locality = $row[2];
@@ -75,11 +75,11 @@ if($result) {
     if(isset($results)) echo "\"position\":\"$results\",";
     if(isset($status)) echo "\"status\":\"$status\",";
     
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo "\"Circuits\":[";
     if($numRows > 0) {
       for($i=1; $i<=$numRows; $i++) {
-        $row = @mysql_fetch_array($result);
+        $row = @mysqli_fetch_array($result);
         $circuitId = $row[0];
         $circuitName = $row[1];
         $locality = $row[2];

--- a/webroot/php/api/ConstructorStandings.inc
+++ b/webroot/php/api/ConstructorStandings.inc
@@ -21,11 +21,11 @@ if($round) {
 
 $query .= " ORDER BY r.year, cs.position LIMIT $offset, $limit";
 //echo "query=$query<br/>\n";
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 
 $query = "SELECT FOUND_ROWS()";
-$found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-$row = mysql_fetch_row($found_rows_result);
+$found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+$row = mysqli_fetch_row($found_rows_result);
 $total = $row[0];
 
 if(strcmp($format, "xml") == 0) {
@@ -37,7 +37,7 @@ if(strcmp($format, "xml") == 0) {
   if(isset($constructorStandings)) echo " constructorStandings=\"$constructorStandings\"";
 
   echo ">\n";  
-  while($row = @mysql_fetch_array($result)) {
+  while($row = @mysqli_fetch_array($result)) {
     $constructorRef = $row[0];
     $name = $row[1];
     $nationality = $row[2];
@@ -78,10 +78,10 @@ if(strcmp($format, "xml") == 0) {
   if(isset($constructor)) echo "\"constructorId\":\"$constructor\",";
   if(isset($constructorStandings)) echo "\"constructorStandings\":\"$constructorStandings\",";
   
-  $numRows = mysql_num_rows($result);
+  $numRows = mysqli_num_rows($result);
   echo "\"StandingsLists\":[";
   if($numRows > 0) {
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $constructorRef = $row[0];
       $name = $row[1];
       $nationality = $row[2];

--- a/webroot/php/api/ConstructorTable.inc
+++ b/webroot/php/api/ConstructorTable.inc
@@ -42,11 +42,11 @@ if($round) {
 $query .= " ORDER BY constructors.name LIMIT $offset, $limit";
 //echo "$query<br>\n<br>\n";
 
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   if(strcmp($format, "xml") == 0) {
     doXMLHeader($url, $series, $limit, $offset, $total);
@@ -63,7 +63,7 @@ if($result) {
     if(isset($results)) echo " position=\"$results\"";
     if(isset($status)) echo " statusId=\"$status\"";
     echo ">\n";
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $constructorId = $row[0];
       $name = $row[1];
       $nationality = $row[2];
@@ -94,11 +94,11 @@ if($result) {
     if(isset($results)) echo "\"position\":\"$results\",";
     if(isset($status)) echo "\"status\":\"$status\",";
     
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo "\"Constructors\":[";
     if($numRows > 0) {
       for($i=1; $i<=$numRows; $i++) {
-        $row = @mysql_fetch_array($result);
+        $row = @mysqli_fetch_array($result);
         $constructorRef = $row[0];
         $name = $row[1];
         $nationality = $row[2];

--- a/webroot/php/api/DriverStandings.inc
+++ b/webroot/php/api/DriverStandings.inc
@@ -20,11 +20,11 @@ if($round) {
 }
 
 $query .= " ORDER BY r.year, ds.position LIMIT $offset, $limit";
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 
 $query = "SELECT FOUND_ROWS()";
-$found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-$row = mysql_fetch_row($found_rows_result);
+$found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+$row = mysqli_fetch_row($found_rows_result);
 $total = $row[0];
 $previousYear = NULL
 
@@ -37,7 +37,7 @@ if(strcmp($format, "xml") == 0) {
   if(isset($driverStandings)) echo " driverStandings=\"$driverStandings\"";
 
   echo ">\n";
-  while($row = @mysql_fetch_array($result)) {
+  while($row = @mysqli_fetch_array($result)) {
     $driverId = $row[0];
     $driverRef = $row[1];
     $permanentNumber = $row[2];
@@ -75,7 +75,7 @@ if(strcmp($format, "xml") == 0) {
     echo "\t\t\t\t</Driver>\n";
     
     $constructorResult = getConstructors($year, $round, $driverId);
-    while($constructorRow = @mysql_fetch_array($constructorResult)) {
+    while($constructorRow = @mysqli_fetch_array($constructorResult)) {
       $constructorRef = $constructorRow[0];
       $constr_name = $constructorRow[1];
       $constr_nationality = $constructorRow[2];
@@ -102,10 +102,10 @@ if(strcmp($format, "xml") == 0) {
   if(isset($driver)) echo "\"driverId\":\"$driver\",";
   if(isset($driverStandings)) echo "\"driverStandings\":\"$driverStandings\",";
   
-  $numRows = mysql_num_rows($result);
+  $numRows = mysqli_num_rows($result);
   echo "\"StandingsLists\":[";
   if($numRows > 0) {
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $driverId = $row[0];
       $driverRef = $row[1];
       $permanentNumber = $row[2];
@@ -153,11 +153,11 @@ if(strcmp($format, "xml") == 0) {
       echo "},";
 
       $constructorResult = getConstructors($year, $round, $driverId);
-      $numRows = mysql_num_rows($constructorResult);
+      $numRows = mysqli_num_rows($constructorResult);
       echo "              \"Constructors\":[";
       if($numRows > 0) {
         for($i=1; $i<=$numRows; $i++) {
-          $constructorRow = @mysql_fetch_array($constructorResult);
+          $constructorRow = @mysqli_fetch_array($constructorResult);
           $constructorRef = $constructorRow[0];
           $constr_name = $constructorRow[1];
           $constr_nationality = $constructorRow[2];
@@ -185,11 +185,12 @@ if(strcmp($format, "xml") == 0) {
 }
 
 function getConstructors($year, $round, $driverId) {
+  global $connection;
   $query = "SELECT DISTINCT c.constructorRef, c.name, c.nationality, c.url FROM constructors c, results re, races ra";
   $query .= " WHERE re.raceId=ra.raceId AND re.driverId='$driverId' AND c.constructorId=re.constructorId";
   $query .= " AND ra.year='$year'"; 
   $query .= " AND ra.round<='$round'";
-  $result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+  $result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
   return $result;
 }
 ?>

--- a/webroot/php/api/DriverTable.inc
+++ b/webroot/php/api/DriverTable.inc
@@ -52,11 +52,11 @@ if($round) {
 $query .= " ORDER BY dr.surname LIMIT $offset, $limit";
 //echo "$query<br>\n<br>\n";
 
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   if(strcmp($format, "xml") == 0) {
     doXMLHeader($url, $series, $limit, $offset, $total);
@@ -73,7 +73,7 @@ if($result) {
     if(isset($results)) echo " position=\"$results\"";
     if(isset($status)) echo " statusId=\"$status\"";
     echo ">\n";
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $driverId = $row[0];
       $permanentNumber = $row[1];
       $code = $row[2];
@@ -115,11 +115,11 @@ if($result) {
     if(isset($results)) echo "\"position\":\"$results\",";
     if(isset($status)) echo "\"status\":\"$status\",";
     
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo "\"Drivers\":[";
     if($numRows > 0) {
       for($i=1; $i<=$numRows; $i++) {
-        $row = @mysql_fetch_array($result);
+        $row = @mysqli_fetch_array($result);
         $driverId = $row[0];
         $permanentNumber = $row[1];
         $code = $row[2];

--- a/webroot/php/api/LapTimes.inc
+++ b/webroot/php/api/LapTimes.inc
@@ -18,12 +18,12 @@ if($laps) $query .= " AND la.lap='$laps'";
 $query .= " ORDER BY la.lap, la.position LIMIT $offset, $limit";
 
 //echo "$query<br>\n<br>\n";
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   $doRaceHeader = true;
   
@@ -36,7 +36,7 @@ if($result) {
     if(isset($driver)) echo " driverId=\"$driver\"";
     if(isset($laps)) echo " lap=\"$laps\"";
     echo ">\n";
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $driverRef = $row[14];
       $lap = $row[15];
       $position = $row[16];
@@ -102,10 +102,10 @@ if($result) {
     if(isset($driver)) echo ",\"driverId\":\"$driver\"";
     if(isset($lap)) echo ",\"lap\":\"$lap\"";
   
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo ",\"Races\":[";
     if($numRows > 0) {
-      while($row = @mysql_fetch_array($result)) {
+      while($row = @mysqli_fetch_array($result)) {
         $driverRef = $row[14];
         $lap = $row[15];
         $position = $row[16];

--- a/webroot/php/api/PitStops.inc
+++ b/webroot/php/api/PitStops.inc
@@ -19,12 +19,12 @@ if($laps) $query .= " AND pi.lap='$laps'";
 $query .= " ORDER BY pi.time LIMIT $offset, $limit";
 
 //echo "$query<br>\n<br>\n";
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   $doRaceHeader = true;
   
@@ -40,7 +40,7 @@ if($result) {
     if(isset($laps)) echo " lap=\"$laps\"";
     echo ">\n";
     
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $driverRef = $row[14];
       $stop = $row[15];
       $lap = $row[16];
@@ -99,10 +99,10 @@ if($result) {
     if(isset($pitstops)) echo ",\"stop\":\"$pitstops\"";
     if(isset($laps)) echo ",\"lap\":\"$laps\"";
     
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo ",\"Races\":[";
     if($numRows > 0) {
-      while($row = @mysql_fetch_array($result)) {
+      while($row = @mysqli_fetch_array($result)) {
         $driverRef = $row[14];
         $stop = $row[15];
         $lap = $row[16];

--- a/webroot/php/api/Qualifying.inc
+++ b/webroot/php/api/Qualifying.inc
@@ -24,12 +24,12 @@ if($results)  $query .= " AND re.positionText='$results'";
 $query .= " ORDER BY ra.year, ra.round, qu.position LIMIT $offset, $limit";
 
 //echo "$query<br>\n<br>\n";
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   
   if(strcmp($format, "xml") == 0) {
@@ -45,7 +45,7 @@ if($result) {
     if(isset($results)) echo " position=\"$results\"";
     if(isset($status)) echo " statusId=\"$status\"";
     echo ">\n";
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $year = $row[0];
       $round = $row[1];
       $number = $row[14];
@@ -144,10 +144,10 @@ if($result) {
     if(isset($results)) echo "\"position\":\"$results\",";
     if(isset($status)) echo "\"status\":\"$status\",";
   
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo "\"Races\":[";
     if($numRows > 0) {
-      while($row = @mysql_fetch_array($result)) {
+      while($row = @mysqli_fetch_array($result)) {
         $year = $row[0];
         $round = $row[1];
         $number = $row[14];

--- a/webroot/php/api/RaceResults.inc
+++ b/webroot/php/api/RaceResults.inc
@@ -23,12 +23,12 @@ if($results) $query .= " AND re.positionText='$results'";
 $query .= " ORDER BY ra.year, ra.round, re.positionOrder LIMIT $offset, $limit";
 
 //echo "$query<br>\n<br>\n";
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   
   if(strcmp($format, "xml") == 0) {
@@ -44,7 +44,7 @@ if($result) {
     if(isset($results)) echo " position=\"$results\"";
     if(isset($status)) echo " statusId=\"$status\"";
     echo ">\n";
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $year = $row[0];
       $round = $row[1];
       $grid = $row[14];
@@ -159,10 +159,10 @@ if($result) {
     if(isset($results)) echo "\"position\":\"$results\",";
     if(isset($status)) echo "\"status\":\"$status\",";
   
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo "\"Races\":[";
     if($numRows > 0) {
-      while($row = @mysql_fetch_array($result)) {
+      while($row = @mysqli_fetch_array($result)) {
         $year = $row[0];
         $round = $row[1];
         $grid = $row[14];

--- a/webroot/php/api/RaceTable.inc
+++ b/webroot/php/api/RaceTable.inc
@@ -20,11 +20,11 @@ if($results) $query .= " AND re.positionText='$results'";
 $query .= " ORDER BY ra.year, ra.round LIMIT $offset, $limit";
 
 //echo "$query<br>\n<br>\n";
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   if(strcmp($format, "xml") == 0) {
     doXMLHeader($url, $series, $limit, $offset, $total);
@@ -39,7 +39,7 @@ if($result) {
     if(isset($results)) echo " position=\"$results\"";
     if(isset($status)) echo " statusId=\"$status\"";
     echo ">\n";
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $season = $row[0];
       $round = $row[1];
       $raceName = $row[2];
@@ -92,11 +92,11 @@ if($result) {
     if(isset($results)) echo "\"position\":\"$results\",";
     if(isset($status)) echo "\"status\":\"$status\",";
     
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo "\"Races\":[";
     if($numRows > 0) {
       for($i=1; $i<=$numRows; $i++) {
-        $row = @mysql_fetch_array($result);
+        $row = @mysqli_fetch_array($result);
         $season = $row[0];
         $round = $row[1];
         $raceName = $row[2];

--- a/webroot/php/api/SeasonTable.inc
+++ b/webroot/php/api/SeasonTable.inc
@@ -53,11 +53,11 @@ if($driverStandings || $constructorStandings) {
 $query .= " ORDER BY s.year LIMIT $offset, $limit";
 //echo "$query<br>\n<br>\n";
 
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   if(strcmp($format, "xml") == 0) {
     doXMLHeader($url, $series, $limit, $offset, $total);
@@ -75,7 +75,7 @@ if($result) {
     if(isset($status)) echo " statusId=\"$status\"";
 
     echo ">\n";
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $season = $row['year'];
       $url = $row['url'];
       echo "\t\t<Season url=\"$url\">$season</Season>\n";
@@ -101,11 +101,11 @@ if($result) {
     if(isset($results)) echo "\"position\":\"$results\",";
     if(isset($status)) echo "\"status\":\"$status\",";
     
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo "\"Seasons\":[";
     if($numRows > 0) {
       for($i=1; $i<=$numRows; $i++) {
-        $row = @mysql_fetch_array($result);
+        $row = @mysqli_fetch_array($result);
         $season = $row['year'];
         $url = escape($row['url']);
         echo "{\"season\":\"$season\",\"url\":\"$url\"}";

--- a/webroot/php/api/SprintResults.inc
+++ b/webroot/php/api/SprintResults.inc
@@ -22,11 +22,11 @@ if($sprint) $query .= " AND sp.positionText='$sprint'";
 $query .= " ORDER BY ra.year, ra.round, sp.positionOrder LIMIT $offset, $limit";
 
 //echo "$query<br>\n<br>\n";
-$result = mysqli_query($mysqli, $query) or die('I cannot select from the database because: ' . mysqli_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysqli_query($mysqli, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
   $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   $currentRound = NULL;

--- a/webroot/php/api/StatusTable.inc
+++ b/webroot/php/api/StatusTable.inc
@@ -24,11 +24,11 @@ if($round) $query .= " AND ra.round='$round'";
 $query .= " GROUP BY st.statusId ORDER BY st.statusId LIMIT $offset, $limit";
 
 //echo "$query<br>\n<br>\n";
-$result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+$result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
 if($result) {
   $query = "SELECT FOUND_ROWS()";
-  $found_rows_result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
-  $row = mysql_fetch_row($found_rows_result);
+  $found_rows_result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
+  $row = mysqli_fetch_row($found_rows_result);
   $total = $row[0];
   if(strcmp($format, "xml") == 0) {
     doXMLHeader($url, $series, $limit, $offset, $total);
@@ -43,7 +43,7 @@ if($result) {
     if(isset($results)) echo " position=\"$results\"";
     if(isset($status)) echo " statusId=\"$status\"";
     echo ">\n";
-    while($row = @mysql_fetch_array($result)) {
+    while($row = @mysqli_fetch_array($result)) {
       $statusId = $row[0];
       $status = $row[1];
       $count = $row[2];
@@ -68,11 +68,11 @@ if($result) {
     if(isset($results)) echo "\"position\":\"$results\",";
     if(isset($status)) echo "\"status\":\"$status\",";
     
-    $numRows = mysql_num_rows($result);
+    $numRows = mysqli_num_rows($result);
     echo "\"Status\":[";
     if($numRows > 0) {
       for($i=1; $i<=$numRows; $i++) {
-        $row = @mysql_fetch_array($result);
+        $row = @mysqli_fetch_array($result);
         $statusId = $row[0];
         $status = $row[1];
         $count = $row[2];

--- a/webroot/php/api/f1dbro.inc
+++ b/webroot/php/api/f1dbro.inc
@@ -1,8 +1,8 @@
 <?php
-$user="root";
-$password="f1";
-$database="ergastdb";
-$connection = mysql_connect("ergastdb", $user, $password);
-mysql_set_charset("utf8", $connection);
-@mysql_select_db($database, $connection) or die("Unable to select database");
+$user = "root";
+$password = "f1";
+$database = "ergastdb";
+$connection = mysqli_connect("ergastdb", $user, $password);
+mysqli_set_charset($connection, "utf8");
+@mysqli_select_db($connection, $database) or die("Unable to select database");
 ?>

--- a/webroot/php/api/functions.inc
+++ b/webroot/php/api/functions.inc
@@ -9,35 +9,38 @@ function clean($string) {
       $string = stripslashes($string);
     }
   }
-  $string = mysql_real_escape_string($string);
+  $string = mysqli_real_escape_string($string);
   return $string;
 }
 
 function currentYear() {
+  global $connection;
   $query = "SELECT MAX(races.year) FROM races, results WHERE races.raceId=results.raceId";
-  $result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+  $result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
   if($result) {
-    $row = @mysql_fetch_array($result);
+    $row = @mysqli_fetch_array($result);
     $year = $row[0];
     return $year;
   }
 }
 
 function lastRound($year) {
+  global $connection;
   $query = "SELECT MAX(races.round) FROM races, results WHERE races.year='$year' AND races.raceId=results.raceId";
-  $result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+  $result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
   if($result) {
-    $row = @mysql_fetch_array($result);
+    $row = @mysqli_fetch_array($result);
     $last = $row[0];
     return $last;
   }
 }
 
 function nextRound($year) {
+  global $connection;
   $query = "SELECT MAX(round) FROM races WHERE year='$year'";
-  $result = mysql_query($query) or die('I cannot select from the database because: ' . mysql_error());
+  $result = mysqli_query($connection, $query) or die('I cannot select from the database because: ' . mysqli_error());
   if($result) {
-    $row = @mysql_fetch_array($result);
+    $row = @mysqli_fetch_array($result);
     $final = $row[0];
     $last = lastRound($year);
     if($last < $final) {

--- a/webroot/php/api/index.php
+++ b/webroot/php/api/index.php
@@ -1,4 +1,7 @@
 <?php
+// FIX: Disable warnings output in webpage
+error_reporting(E_ERROR | E_PARSE);
+
 include("functions.inc");
 
 $urlComponents = parse_url($_SERVER['REQUEST_URI']);
@@ -10,7 +13,7 @@ if($period !== FALSE) {
   $path = substr($path, 0, $period);
   if(strcmp($format, "xml") != 0 && strcmp($format, "json") != 0) error(404, "Format not found.");
 } else {
-  $format = "xml";  // Default. 
+  $format = "xml";  // Default.
 }
 
 parse_str($urlComponents['query'], $fields);


### PR DESCRIPTION
- Updated the DB container to use MySQL 8.2, currently the latest stable version. Seems to work fine.
- Updated the web (PHP+Apache) container to use PHP 8.2, same as above. I fixed the minimum necessary to make the container run, but there still are some warnings left. I had to suppress the warnings because otherwise they would get printed in the response (see `index.php`).
All the errors happen because of PHP 8, as the code works fine with PHP 7.4 and below, but all those versions have reached EOL.
- Some PHP files had CRLF endings instead of LF like the others, I converted all to use LF.